### PR TITLE
Remove duplicated port entry for the pam-generic section

### DIFF
--- a/templates/etc/fail2ban/jail.local.j2
+++ b/templates/etc/fail2ban/jail.local.j2
@@ -145,7 +145,6 @@ filter   = pam-generic
 # port actually must be irrelevant but lets leave it all for some possible uses
 port     = all
 banaction = iptables-allports
-port     = anyport
 logpath  = /var/log/auth.log
 maxretry = 6
 


### PR DESCRIPTION
It failed to start for me, with a message saying that the port for pam-generic was defined twice.

Other than that, worked like a charm, and saved me some hours.

Thank you very much!!!
Bruno